### PR TITLE
Use static war instead of redirect

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -120,6 +120,7 @@
     </dependencies>
 
     <build>
+        <finalName>${project.artifactId}</finalName>
         <plugins>
             <plugin>
                 <groupId>com.vaadin</groupId>
@@ -130,6 +131,47 @@
                         <goals>
                             <goal>prepare-frontend</goal>
                         </goals>
+                    </execution>
+                </executions>
+            </plugin>
+
+            <!-- Build 2 war files. one containing portlet and one containing all static files -->
+            <plugin>
+                <groupId>org.apache.maven.plugins</groupId>
+                <artifactId>maven-war-plugin</artifactId>
+                <version>3.2.3</version>
+                <executions>
+                    <execution>
+                        <id>portlet-war</id>
+                        <goals>
+                            <goal>war</goal>
+                        </goals>
+                        <configuration>
+                            <packagingExcludes>WEB-INF/classes/META-INF/VAADIN/build/**,VAADIN/</packagingExcludes>
+                        </configuration>
+                    </execution>
+                    <execution>
+                        <id>static-files</id>
+                        <goals>
+                            <goal>war</goal>
+                        </goals>
+                        <configuration>
+                            <warName>vaadin-portlet-static</warName>
+                            <packagingIncludes>WEB-INF/lib/flow-client*.jar,VAADIN/</packagingIncludes>
+
+                            <webResources>
+                                <resource>
+                                    <!-- this is relative to the pom.xml directory -->
+                                    <directory>target/classes/META-INF/</directory>
+                                    <includes>
+                                        <include>**</include>
+                                    </includes>
+                                    <excludes>
+                                        <exclude>VAADIN/config/**</exclude>
+                                    </excludes>
+                                </resource>
+                            </webResources>
+                        </configuration>
                     </execution>
                 </executions>
             </plugin>
@@ -151,6 +193,12 @@
                     <artifactId>flow-server-production-mode</artifactId>
                     <version>${flow.version}</version>
                 </dependency>
+
+                <dependency>
+                    <groupId>javax.portlet</groupId>
+                    <artifactId>portlet-api</artifactId>
+                    <version>2.0</version>
+                </dependency>
             </dependencies>
 
             <build>
@@ -164,10 +212,10 @@
                                 <goals>
                                     <goal>build-frontend</goal>
                                 </goals>
-                                <phase>compile</phase>
                             </execution>
                         </executions>
                     </plugin>
+
                 </plugins>
             </build>
         </profile>

--- a/rewrite.config
+++ b/rewrite.config
@@ -1,1 +1,0 @@
-RewriteRule ^/VAADIN/(.*)$ /testsuite/VAADIN/$1 [L]


### PR DESCRIPTION
Don't redirect requests to test war,
but use the vaadin-portlet-static.war
instead.

Not yet compatible with -Pdemo
as the static war isn't deployed.

After this the WIKI should be updated to say 
to copy the 2 war files to webapps folder.

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-flow-portlet/3)
<!-- Reviewable:end -->
