### PR TITLE
Additional demo profile including the dependencies needed for running Pluto under Java 11

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,7 +12,8 @@ The documentation for Vaadin Portlet support is available [here](https://github.
 Before the portlet application can be run, it must be deployed to a portal. 
 We currently support Apache Pluto (https://portals.apache.org/pluto/). The
 easiest way to try out your application is to run a Maven goal which starts an 
-embedded Tomcat 8 serving the Pluto Portal driver:
+embedded Tomcat 8 serving the Pluto Portal driver (for Java 10 or newer JDKs,
+also add the `demo-java10` profile):
 
 `mvn package cargo:run -Pdemo,production`
 

--- a/README.md
+++ b/README.md
@@ -12,8 +12,7 @@ The documentation for Vaadin Portlet support is available [here](https://github.
 Before the portlet application can be run, it must be deployed to a portal. 
 We currently support Apache Pluto (https://portals.apache.org/pluto/). The
 easiest way to try out your application is to run a Maven goal which starts an 
-embedded Tomcat 8 serving the Pluto Portal driver (for Java 10 or newer JDKs,
-also add the `demo-java10` profile):
+embedded Tomcat 8 serving the Pluto Portal driver:
 
 `mvn package cargo:run -Pdemo,production`
 

--- a/pom.xml
+++ b/pom.xml
@@ -328,6 +328,68 @@
                 </plugins>
             </build>
         </profile>
+
+        <profile>
+            <id>demo-java10</id>
+            <dependencies>
+                <dependency>
+                    <groupId>javax.xml.bind</groupId>
+                    <artifactId>jaxb-api</artifactId>
+                    <version>2.2.11</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-core</artifactId>
+                    <version>2.2.11</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>com.sun.xml.bind</groupId>
+                    <artifactId>jaxb-impl</artifactId>
+                    <version>2.2.11</version>
+                    <scope>provided</scope>
+                </dependency>
+                <dependency>
+                    <groupId>javax.activation</groupId>
+                    <artifactId>activation</artifactId>
+                    <version>1.1.1</version>
+                    <scope>provided</scope>
+                </dependency>
+            </dependencies>
+            <build>
+                <plugins>
+                    <plugin>
+                        <groupId>org.codehaus.cargo</groupId>
+                        <artifactId>cargo-maven2-plugin</artifactId>
+                        <configuration>
+                            <container>
+                                <containerId>tomcat8x</containerId>
+                                <dependencies>
+                                    <dependency>
+                                        <groupId>javax.xml.bind</groupId>
+                                        <artifactId>jaxb-api</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>com.sun.xml.bind</groupId>
+                                        <artifactId>jaxb-core</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>com.sun.xml.bind</groupId>
+                                        <artifactId>jaxb-impl</artifactId>
+                                    </dependency>
+                                    <dependency>
+                                        <groupId>javax.activation</groupId>
+                                        <artifactId>activation</artifactId>
+                                    </dependency>
+                                </dependencies>
+                            </container>
+                        </configuration>
+                    </plugin>
+                </plugins>
+            </build>
+        </profile>
+
         <profile>
             <id>integration-tests</id>
 

--- a/pom.xml
+++ b/pom.xml
@@ -330,7 +330,10 @@
         </profile>
 
         <profile>
-            <id>demo-java10</id>
+            <id>java11</id>
+            <activation>
+              <jdk>[11,)</jdk>
+            </activation>
             <dependencies>
                 <dependency>
                     <groupId>javax.xml.bind</groupId>
@@ -358,35 +361,37 @@
                 </dependency>
             </dependencies>
             <build>
-                <plugins>
-                    <plugin>
-                        <groupId>org.codehaus.cargo</groupId>
-                        <artifactId>cargo-maven2-plugin</artifactId>
-                        <configuration>
-                            <container>
-                                <containerId>tomcat8x</containerId>
-                                <dependencies>
-                                    <dependency>
-                                        <groupId>javax.xml.bind</groupId>
-                                        <artifactId>jaxb-api</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>com.sun.xml.bind</groupId>
-                                        <artifactId>jaxb-core</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>com.sun.xml.bind</groupId>
-                                        <artifactId>jaxb-impl</artifactId>
-                                    </dependency>
-                                    <dependency>
-                                        <groupId>javax.activation</groupId>
-                                        <artifactId>activation</artifactId>
-                                    </dependency>
-                                </dependencies>
-                            </container>
-                        </configuration>
-                    </plugin>
-                </plugins>
+                <pluginManagement>
+                    <plugins>
+                        <plugin>
+                            <groupId>org.codehaus.cargo</groupId>
+                            <artifactId>cargo-maven2-plugin</artifactId>
+                            <configuration>
+                                <container>
+                                    <containerId>tomcat8x</containerId>
+                                    <dependencies>
+                                        <dependency>
+                                            <groupId>javax.xml.bind</groupId>
+                                            <artifactId>jaxb-api</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>com.sun.xml.bind</groupId>
+                                            <artifactId>jaxb-core</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>com.sun.xml.bind</groupId>
+                                            <artifactId>jaxb-impl</artifactId>
+                                        </dependency>
+                                        <dependency>
+                                            <groupId>javax.activation</groupId>
+                                            <artifactId>activation</artifactId>
+                                        </dependency>
+                                    </dependencies>
+                                </container>
+                            </configuration>
+                        </plugin>
+                    </plugins>
+                </pluginManagement>
             </build>
         </profile>
 


### PR DESCRIPTION
@pleku @enver-haase The following dependency additions should enable running the portlet demo under JDKs which no longer includes jaxb-api (thanks @ZheSun88). It requires the profile `demo-java10` in addition to the other profiles (`demo`, `production`).

(We should consider activating demo by property instead of profile, then this could probably be activated automatically by `<jdk>[10,</jdk>` )

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-flow-portlet/16)
<!-- Reviewable:end -->
