### PR TITLE
Use https for tomcat bundle url in cargo maven plugin

### DIFF
--- a/pom.xml
+++ b/pom.xml
@@ -278,6 +278,9 @@
                         <configuration>
                             <container>
                                 <containerId>tomcat8x</containerId>
+                                <zipUrlInstaller>
+                                    <url>https://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/8.5.50/tomcat-8.5.50.zip</url>
+                                </zipUrlInstaller>
                             </container>
                             <configuration>
                                 <type>existing</type>


### PR DESCRIPTION
Fixes the following error when running the project.

```
[ERROR] Failed to execute goal org.codehaus.cargo:cargo-maven2-plugin:1.7.7:start
    (start-portal) on project portlet-starter: Execution start-portal of goal 
    org.codehaus.cargo:cargo-maven2-plugin:1.7.7:start failed: Failed to download 
    [http://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/8.5.43/tomcat-8.5.43.zip]: 
    Can't get http://repo.maven.apache.org/maven2/org/apache/tomcat/tomcat/8.5.43/tomcat-8.5.43.zip 
    to /opt/agent/temp/buildTmp/cargo/installs/tomcat-8.5.43.zip -> [Help 1]
```

<!-- Reviewable:start -->
---
This change is [<img src="https://reviewable.io/review_button.svg" height="34" align="absmiddle" alt="Reviewable"/>](https://reviewable.io/reviews/vaadin/base-starter-flow-portlet/30)
<!-- Reviewable:end -->
